### PR TITLE
Add engineering onboarding doc

### DIFF
--- a/engineering-onboarding.md
+++ b/engineering-onboarding.md
@@ -1,0 +1,26 @@
+# Engineering onboarding
+
+#### Use a password manager
+- [LastPass](https://lastpass.com/) is one option, but use whatever tool you like.
+- Treat account passwords as secrets.  Don't email passwords or share them in Slack.
+
+#### GitHub
+- Create GitHub user if you don’t have one
+- Set up two-factor auth
+- Ask someone to add you to our public GitHub organization (https://github.com/mit-teaching-systems-lab)
+- Verify it works
+
+#### Private MIT GitHub
+- Create private MIT GitHub user if you don’t have one (http://kb.mit.edu/confluence/display/istcontrib/GitHub.mit.edu+Overview)
+- Verify MIT kerberos is working
+- Ask someone to invite you to our private MIT GitHub organization
+- Verify it works
+
+#### Amazon
+- Create an AWS account
+- Set up two-factor auth
+- Ask someone to invite you to the appropriate AWS groups
+- Verify you can use services in AWS console (eg., S3)
+
+### Heroku
+- Ask someone to invite you to the Heroku apps you need


### PR DESCRIPTION
This captures the additional onboarding steps for folks doing engineering work in the lab (in additional to the generic onboarding with chat, mailing lists, etc.).
