### PR TITLE
Use pull requests from forks, instead of from upstream repo

### DIFF
--- a/working-agreement.md
+++ b/working-agreement.md
@@ -9,8 +9,8 @@ Check all projects into GitHub or MIT GitHub, so that everyone on the team has a
 #### Keep master green
 The master branch should always be deployable and pass all tests.  If master is broken, consider reverting immediately and fixing the underlying issue in a separate pull request.
 
-#### Make changes through pull requests
-Use pull requests to make any changes, and do this regularly as you're making progress.  All pull requests should be approved before merging, even if they are self-approved.  For more information check out https://help.github.com/articles/using-pull-requests/ or the guides in https://guides.github.com/.
+#### Make changes through pull requests from forks
+Use pull requests from your own fork to make any changes, and do this regularly as you're making progress.  All pull requests should be approved before merging, even if they are self-approved.  For more information check out https://help.github.com/articles/using-pull-requests/ or the guides in https://guides.github.com/.
 
 #### Ask for feedback
 Every developer has commit access, and it’s up to them to decide how to get approval on pull requests.  Sometimes explicit review is appropriate, sometimes an after-the-fact review is appropriate, and sometimes self-approval is appropriate.  If you’re not sure, default towards asking someone to review before merging.


### PR DESCRIPTION
The idea here is that we submit pull requests from forks, which is essentially the same but then there aren't other branches on the main repo, so it's a wee bit simpler.

@david-rosales We can try this out tomorrow too!
